### PR TITLE
Improve VPN and UMG connectivity handling

### DIFF
--- a/prognoza/interfaces/cli.py
+++ b/prognoza/interfaces/cli.py
@@ -104,7 +104,12 @@ def read_umg(
             typer.echo(f"{key}: {value:.3f}")
 
     if auto_vpn and settings.router.openvpn_profile:
-        manager = create_vpn_manager(settings.router, timeout_s=vpn_timeout)
+        manager = None
+        try:
+            manager = create_vpn_manager(settings.router, timeout_s=vpn_timeout)
+        except OpenVPNError as exc:
+            typer.echo(f"Eroare la pregatirea tunelului VPN: {exc}")
+            raise typer.Exit(code=2)
         try:
             typer.echo("Pornire tunel OpenVPN...")
             manager.start(timeout_s=vpn_timeout)
@@ -117,7 +122,8 @@ def read_umg(
                 typer.echo(f"Verifica logul: {manager.log_file}")
             raise typer.Exit(code=2)
         finally:
-            manager.stop()
+            if manager:
+                manager.stop()
     else:
         _read()
 


### PR DESCRIPTION
## Summary
- resolve router file paths relative to the configuration file and recognise Windows-style absolute paths
- honour configurable retry counts when polling the UMG 509 reader and surface the last connection error
- harden OpenVPN startup by validating profile/executable paths, keeping failure logs and improving CLI error handling

## Testing
- python -m compileall prognoza

------
https://chatgpt.com/codex/tasks/task_e_68d3ddb1b830833096131c5e47168a55