### PR TITLE
Add comprehensive pytest suite with fixtures and mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ python -m app poll-loop --minutes 1 --cycles 10
 
 Proiectul include un nou CLI bilingual (RO/EN) bazat pe Typer + Rich:
 
+## Running tests
+
+The repository ships with a deterministic pytest suite. Ensure dependencies are installed, then execute:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+Test logs are written to `logs/tests/` for easier triage.
+
 ```bash
 # English examples
 python -m cli.app vpn status

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,234 @@
+"""Shared pytest configuration and fixtures for PROGNOZA."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Dict, Generator, Iterable, Tuple
+
+import pandas as pd
+import pytest
+
+from tests.helpers import (
+    FakeHttpResponse,
+    FakeModbusClient,
+    FakeOpenVPNManager,
+    FakeProvider,
+    build_fake_umg_frame,
+    build_fake_weather_frame,
+    ensure_directory,
+    write_csv,
+    write_parquet,
+)
+
+LOGS_ROOT = Path(__file__).resolve().parents[1] / "logs" / "tests"
+SESSION_LOG = LOGS_ROOT / "pytest.session.log"
+_MODULE_HANDLERS: Dict[str, logging.Handler] = {}
+
+
+def _initialise_logging() -> None:
+    LOGS_ROOT.mkdir(parents=True, exist_ok=True)
+    (LOGS_ROOT / ".gitkeep").touch(exist_ok=True)
+
+    handler = logging.FileHandler(SESSION_LOG, mode="w", encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
+    root.addHandler(handler)
+
+
+def get_test_logger(module_name: str) -> logging.Logger:
+    """Return a logger writing into ``logs/tests/<module>.log``."""
+    normalised = module_name.replace("tests.", "")
+    logger = logging.getLogger(f"tests.{normalised}")
+    logger.setLevel(logging.INFO)
+    if normalised not in _MODULE_HANDLERS:
+        log_path = LOGS_ROOT / f"{normalised}.log"
+        handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+        logger.addHandler(handler)
+        _MODULE_HANDLERS[normalised] = handler
+    return logger
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:  # noqa: D401 - pytest hook
+    _initialise_logging()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]) -> Iterable[pytest.TestReport]:
+    outcome = yield
+    report = outcome.get_result()
+    if report.outcome != "failed":
+        return
+    module = getattr(item, "module", None)
+    module_name = getattr(module, "__name__", "tests")
+    target = LOGS_ROOT / f"{module_name.split('.')[-1]}.log"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write("\n=== TEST FAILURE ===\n")
+        handle.write(f"nodeid: {item.nodeid}\n")
+        handle.write(f"phase: {report.when}\n")
+        handle.write(str(report.longrepr))
+        handle.write("\n")
+
+
+@pytest.fixture(scope="session")
+def project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="session")
+def logs_dir() -> Path:
+    _initialise_logging()
+    return LOGS_ROOT
+
+
+@pytest.fixture
+def fake_umg_csv(tmp_path: Path) -> Path:
+    frame = build_fake_umg_frame()
+    path = tmp_path / "umg" / "measurements_20240101.csv"
+    return write_csv(frame, path)
+
+
+@pytest.fixture
+def fake_weather_parquet(tmp_path: Path) -> Path:
+    frame = build_fake_weather_frame()
+    path = tmp_path / "weather" / "weather_hourly.parquet"
+    return write_parquet(frame, path)
+
+
+@pytest.fixture
+def mock_vpn(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    from app import vpn_connection
+
+    assets_dir = tmp_path / "assets"
+    profile_path = tmp_path / "profile.ovpn"
+    profile_path.write_text("client\n", encoding="utf-8")
+
+    monkeypatch.setattr(vpn_connection.settings, "OVPN_ASSETS_DIR", assets_dir)
+    monkeypatch.setattr(vpn_connection.settings, "LOG_FILE", tmp_path / "vpn.log")
+    monkeypatch.setattr(vpn_connection.settings, "OVPN_INPUT", profile_path)
+    monkeypatch.setattr(vpn_connection.settings, "PROFILE_NAME", "pytest-profile")
+    monkeypatch.setattr(vpn_connection.settings, "CONNECT_TIMEOUT_S", 5)
+    monkeypatch.setattr(vpn_connection.settings, "UMG_IP", "192.168.50.10")
+    monkeypatch.setattr(vpn_connection.settings, "UMG_TCP_PORT", 502)
+
+    monkeypatch.setattr(vpn_connection, "OpenVPNManager", FakeOpenVPNManager)
+    monkeypatch.setattr(
+        vpn_connection.ovpn_config,
+        "parse_ovpn_file",
+        lambda path: {"text": "client\n"},
+    )
+    monkeypatch.setattr(
+        vpn_connection.ovpn_config,
+        "generate_clean_config",
+        lambda *args, **kwargs: "client\n",
+    )
+
+    def _write(clean_text: str, assets_dir: Path, profile_name: str) -> Path:
+        assets_dir.mkdir(parents=True, exist_ok=True)
+        out = assets_dir / f"{profile_name}.ovpn"
+        out.write_text(clean_text, encoding="utf-8")
+        return out
+
+    monkeypatch.setattr(vpn_connection.ovpn_config, "write_clean_files", _write)
+    monkeypatch.setattr(vpn_connection.VPNConnection, "_wait_for_ip", lambda self, timeout_s: "10.8.0.2")
+    monkeypatch.setattr(
+        vpn_connection.VPNConnection,
+        "_test_umg_connectivity",
+        lambda self, timeout_s, min_attempts: (True, True, True),
+    )
+    monkeypatch.setattr(vpn_connection.VPNConnection, "_get_vpn_ip", lambda self: "10.8.0.2")
+    return tmp_path
+
+
+@pytest.fixture
+def mock_modbus(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app import janitza_client
+
+    monkeypatch.setattr(janitza_client, "ModbusTcpClient", FakeModbusClient)
+    monkeypatch.setattr(janitza_client.JanitzaUMG, "tcp_ping", staticmethod(lambda *_, **__: 12.5))
+    monkeypatch.setattr(
+        janitza_client.JanitzaUMG,
+        "_read_batch",
+        lambda self, client, start, count: [round(0.1 * idx, 3) for idx in range(count)],
+    )
+    monkeypatch.setattr(
+        janitza_client.JanitzaUMG,
+        "_read_float",
+        lambda self, client, address: round((address % 100) / 10.0, 3),
+    )
+
+
+@pytest.fixture
+def mock_http(monkeypatch: pytest.MonkeyPatch) -> Dict[str, Any]:
+    import requests
+
+    payload = {
+        "hourly": {
+            "time": ["2024-01-01T00:00:00Z", "2024-01-01T01:00:00Z"],
+            "temperature_2m": [5.0, 6.0],
+            "windspeed_10m": [3.2, 3.4],
+            "winddirection_10m": [180, 200],
+            "cloudcover": [20, 30],
+            "relativehumidity_2m": [60, 62],
+            "surface_solar_radiation_downward": [100.0, 120.0],
+        }
+    }
+
+    def _fake_get(*args, **kwargs):
+        return FakeHttpResponse(payload)
+
+    class _Session:
+        def get(self, *args, **kwargs):
+            return _fake_get(*args, **kwargs)
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+    monkeypatch.setattr(requests, "Session", lambda: _Session())
+    return payload
+
+
+@pytest.fixture
+def mock_uvicorn(monkeypatch: pytest.MonkeyPatch) -> Dict[str, Tuple[str, int, bool]]:
+    calls: Dict[str, Tuple[str, int, bool]] = {}
+
+    def _fake_start(host: str, port: int, *, open_browser: bool = True) -> None:
+        calls["start"] = (host, port, open_browser)
+
+    monkeypatch.setattr("ui.server.start_ui", _fake_start)
+    return calls
+
+
+@pytest.fixture(scope="session")
+def weather_cache_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp("weather-cache") / "cache.sqlite"
+
+
+@pytest.fixture(autouse=True)
+def patch_weather_cache(monkeypatch: pytest.MonkeyPatch, weather_cache_dir: Path) -> None:
+    from weather import cache as weather_cache
+
+    def _factory(path: Path | None = None) -> weather_cache.WeatherCache:
+        target = path or weather_cache_dir
+        return weather_cache.WeatherCache(path=target)
+
+    monkeypatch.setattr(weather_cache.WeatherCache, "default", classmethod(lambda cls: _factory()))
+
+
+@pytest.fixture(autouse=True)
+def clear_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "TOMORROW_IO_API_KEY", "TOMORROWIO_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+
+__all__ = [
+    "get_test_logger",
+]

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,24 @@
+"""Shared helper utilities for the PROGNOZA test-suite."""
+
+from .data import build_fake_umg_frame, build_fake_weather_frame, write_csv, write_parquet
+from .fs import ensure_directory
+from .mocks import (
+    FakeHttpResponse,
+    FakeModbusClient,
+    FakeOpenVPNManager,
+    FakeProvider,
+    FakeVpnConnection,
+)
+
+__all__ = [
+    "build_fake_umg_frame",
+    "build_fake_weather_frame",
+    "write_csv",
+    "write_parquet",
+    "ensure_directory",
+    "FakeHttpResponse",
+    "FakeModbusClient",
+    "FakeOpenVPNManager",
+    "FakeProvider",
+    "FakeVpnConnection",
+]

--- a/tests/helpers/data.py
+++ b/tests/helpers/data.py
@@ -1,0 +1,86 @@
+"""Synthetic data builders used across the pytest suite."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "build_fake_umg_frame",
+    "build_fake_weather_frame",
+    "write_csv",
+    "write_parquet",
+]
+
+
+def build_fake_umg_frame(
+    *,
+    start: str | datetime = "2024-01-01T00:00:00Z",
+    periods: int = 60,
+    freq: str = "1min",
+) -> pd.DataFrame:
+    """Return a Janitza-like measurement dataframe with deterministic values."""
+    index = pd.date_range(start=start, periods=periods, freq=freq, tz="UTC")
+    base = np.linspace(0, 2 * np.pi, periods, endpoint=False)
+    utc_index = index.tz_convert("UTC")
+    frame = pd.DataFrame(
+        {
+            "timestamp": utc_index.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "power_active_total": 50 + 10 * np.sin(base),
+            "power_reactive_total": 5 + 2 * np.cos(base),
+            "power_apparent_total": 60 + 8 * np.sin(base / 2),
+            "voltage_l1": 230 + 5 * np.sin(base / 3),
+            "current_l1": 10 + np.cos(base),
+            "frequency": 50 + 0.02 * np.sin(base * 3),
+            "power_factor": 0.95 + 0.02 * np.cos(base * 2),
+            "thd_voltage_l1": 1.5 + 0.1 * np.sin(base * 1.5),
+            "thd_current_l1": 2.5 + 0.1 * np.cos(base * 1.5),
+        }
+    )
+    frame["power_W"] = frame["power_active_total"] * 1000 / 3.6  # convert to W-ish
+    return frame
+
+
+def build_fake_weather_frame(
+    *,
+    start: str | datetime = "2024-01-01T00:00:00Z",
+    periods: int = 72,
+    freq: str = "1h",
+) -> pd.DataFrame:
+    """Return a deterministic hourly weather dataframe."""
+    index = pd.date_range(start=start, periods=periods, freq=freq, tz="UTC")
+    hours = np.arange(periods)
+    frame = pd.DataFrame(
+        {
+            "temp_C": 5 + 10 * np.sin(hours / 24 * 2 * np.pi),
+            "wind_ms": 3 + np.cos(hours / 12 * 2 * np.pi),
+            "wind_deg": (hours * 15) % 360,
+            "clouds_pct": np.clip(50 + 30 * np.sin(hours / 6), 0, 100),
+            "humidity": np.clip(60 + 10 * np.cos(hours / 5), 0, 100),
+            "uvi": np.clip(2 + np.sin(hours / 24 * 2 * np.pi), 0, None),
+            "ghi_Wm2": np.clip(100 + 50 * np.sin(hours / 24 * 2 * np.pi), 0, None),
+        },
+        index=index,
+    )
+    return frame
+
+
+def write_csv(frame: pd.DataFrame, path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_csv(path, index=False)
+    return path
+
+
+def write_parquet(frame: pd.DataFrame, path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        frame.to_parquet(path)
+    except ImportError:  # pragma: no cover - optional dependency fallback
+        fallback = path.with_suffix(".csv")
+        frame.to_csv(fallback)
+        return fallback
+    return path

--- a/tests/helpers/fs.py
+++ b/tests/helpers/fs.py
@@ -1,0 +1,13 @@
+"""Filesystem helpers for the pytest suite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["ensure_directory"]
+
+
+def ensure_directory(path: Path) -> Path:
+    """Create parent directories for ``path`` and return the path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path

--- a/tests/helpers/mocks.py
+++ b/tests/helpers/mocks.py
@@ -1,0 +1,192 @@
+"""Mock implementations used by the pytest suite."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, Callable, Dict, Optional
+
+import pandas as pd
+
+from weather.core import ForecastFrame, Provider
+
+__all__ = [
+    "FakeHttpResponse",
+    "FakeModbusClient",
+    "FakeOpenVPNManager",
+    "FakeProvider",
+    "FakeVpnConnection",
+]
+
+
+class FakeHttpResponse:
+    """Minimal response object for mocked HTTP calls."""
+
+    def __init__(self, payload: Dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.text = ""
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class FakeModbusClient:
+    """In-memory Modbus client returning deterministic float values."""
+
+    def __init__(self, host: str, port: int, timeout: float) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.connected = False
+
+    def connect(self) -> bool:  # pragma: no cover - trivial
+        self.connected = True
+        return True
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        self.connected = False
+
+    @staticmethod
+    def _float_from_address(address: int) -> float:
+        return round((address % 1000) / 10.0, 3)
+
+    def read_holding_registers(self, address: int, count: int, slave: int) -> SimpleNamespace:
+        registers = []
+        for offset in range(count * 2):
+            base = self._float_from_address(address + offset)
+            registers.append(int(base * 100))
+        return SimpleNamespace(isError=lambda: False, registers=registers)
+
+
+class FakeOpenVPNManager:
+    """Fake manager that records lifecycle calls for assertions."""
+
+    def __init__(self, logger: Any) -> None:
+        self.logger = logger
+        self.profile_running = False
+        self.pid = 4242
+
+    def prepare_profile(self, clean_profile: Any, assets_dir: Any, profile_name: str) -> str:
+        return f"{assets_dir}/{profile_name}.ovpn"
+
+    def start(self, profile_name: str) -> Dict[str, Any]:
+        self.profile_running = True
+        return {"pid": self.pid}
+
+    def disconnect(self, profile_name: str) -> None:
+        self.profile_running = False
+
+    def stop_all(self) -> None:
+        self.profile_running = False
+
+    def get_profile_pid(self, profile_name: str) -> Optional[int]:
+        return self.pid if self.profile_running else None
+
+
+class _MemoryCache:
+    def __init__(self) -> None:
+        self._storage: Dict[tuple[str, str, str], tuple[float, pd.DataFrame]] = {}
+
+    def get(self, provider: str, scope: str, cache_key: str) -> Optional[pd.DataFrame]:
+        key = (provider, scope, cache_key)
+        payload = self._storage.get(key)
+        if not payload:
+            return None
+        expires_at, frame = payload
+        if expires_at < time.time():
+            self._storage.pop(key, None)
+            return None
+        return frame.copy()
+
+    def set(
+        self,
+        provider: str,
+        scope: str,
+        cache_key: str,
+        frame: pd.DataFrame,
+        ttl_seconds: int,
+    ) -> None:
+        self._storage[(provider, scope, cache_key)] = (time.time() + ttl_seconds, frame.copy())
+
+
+@dataclass
+class FakeProvider(Provider):
+    """Deterministic provider used to exercise :class:`WeatherRouter`."""
+
+    name: str
+    priority: int = 10
+    hourly_builder: Callable[[pd.Timestamp, pd.Timestamp], pd.DataFrame] = field(
+        default=lambda start, end: pd.DataFrame()
+    )
+    nowcast_builder: Optional[Callable[[int], pd.DataFrame]] = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass init
+        super().__init__(self.name, priority=self.priority, cache=_MemoryCache(), ttl=300)
+
+    def get_hourly(self, start: Any, end: Any) -> ForecastFrame:
+        start_ts = pd.Timestamp(start)
+        if start_ts.tzinfo is None:
+            start_ts = start_ts.tz_localize("UTC")
+        else:
+            start_ts = start_ts.tz_convert("UTC")
+
+        end_ts = pd.Timestamp(end)
+        if end_ts.tzinfo is None:
+            end_ts = end_ts.tz_localize("UTC")
+        else:
+            end_ts = end_ts.tz_convert("UTC")
+
+        def _builder() -> pd.DataFrame:
+            frame = self.hourly_builder(start_ts, end_ts)
+            frame.index = pd.to_datetime(frame.index, utc=True)
+            return frame
+
+        frame = self.fetch_with_cache(
+            "hourly",
+            {"start": start_ts.isoformat(), "end": end_ts.isoformat()},
+            _builder,
+            ttl=60,
+        )
+        return ForecastFrame(frame, {"source": self.name})
+
+    def supports_nowcast(self) -> bool:
+        return self.nowcast_builder is not None
+
+    def get_nowcast(self, next_hours: int = 2) -> ForecastFrame:
+        if not self.nowcast_builder:
+            raise RuntimeError("Nowcast not available")
+        def _builder() -> pd.DataFrame:
+            frame = self.nowcast_builder(next_hours)
+            frame.index = pd.to_datetime(frame.index, utc=True)
+            return frame
+
+        frame = self.fetch_with_cache(
+            "nowcast",
+            {"horizon": int(next_hours)},
+            _builder,
+            ttl=15,
+        )
+        return ForecastFrame(frame, {"source": self.name})
+
+
+class FakeVpnConnection:
+    """Simplified VPN connection used for CLI simulations."""
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.history: list[str] = []
+
+    def connect(self) -> Dict[str, Any]:
+        self.connected = True
+        self.history.append("connect")
+        return {"is_connected": True, "vpn_ip": "10.8.0.2", "umg_ok": True}
+
+    def disconnect(self) -> None:
+        self.connected = False
+        self.history.append("disconnect")
+
+    def status(self) -> Dict[str, Any]:
+        self.history.append("status")
+        return {"is_connected": self.connected, "vpn_ip": "10.8.0.2", "umg_ok": self.connected}

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,59 @@
+"""Unit tests for the AI orchestrator facade."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.conftest import get_test_logger
+
+logger = get_test_logger(__name__)
+logger.info("Starting tests for AI orchestrator module")
+
+
+def test_ai_orchestrator_interfaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure orchestrator delegates to mocked strategy components."""
+    from ai import orchestrator as orchestrator_module
+
+    logger.info("Running AI orchestrator delegation test")
+
+    class DummySelector:
+        def __init__(self, config):
+            self.config = config
+            self.provider_registry = SimpleNamespace(first_available=lambda: None)
+
+        def select_model(self, context):
+            return {"choice": "physics", "confidence": 0.95, "source": "rules"}
+
+    class DummyDriftAnalyzer:
+        def __init__(self, config):
+            self.config = config
+
+        def drift_summary(self, ref_stats, cur_stats):
+            return {"drift_score": 0.12, "top_features": ["temp_C", "ghi_Wm2"]}
+
+    class DummyExplainer:
+        def __init__(self, config, registry):
+            self.config = config
+            self.registry = registry
+
+        def explain_forecast(self, context):
+            return "## Forecast rationale\n- Stable outlook"
+
+    monkeypatch.setattr(orchestrator_module, "ModelSelector", DummySelector)
+    monkeypatch.setattr(orchestrator_module, "DriftAnalyzer", DummyDriftAnalyzer)
+    monkeypatch.setattr(orchestrator_module, "ForecastExplainer", DummyExplainer)
+
+    orchestrator = orchestrator_module.AIOrchestrator(config={})
+
+    decision = orchestrator.select_model({"metrics": {"mape_intraday": 4.2}})
+    assert decision["choice"] == "physics"
+    assert decision["source"] == "rules"
+
+    summary = orchestrator.summarize_drift({"reference_stats": {}, "current_stats": {}})
+    assert pytest.approx(summary["drift_score"], rel=1e-3) == 0.12
+    assert "temp_C" in summary["top_features"]
+
+    explanation = orchestrator.explain_forecast({"forecast": []})
+    assert explanation.startswith("## Forecast rationale")

--- a/tests/test_ai_hibrid.py
+++ b/tests/test_ai_hibrid.py
@@ -1,0 +1,98 @@
+"""Tests for the hybrid AI pipeline training and prediction flows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tests.conftest import get_test_logger
+
+logger = get_test_logger(__name__)
+logger.info("Starting tests for AI Hibrid module")
+
+
+class DummyModel:
+    """Serializable placeholder model used in tests."""
+
+    def __init__(self, bias: float) -> None:
+        self.bias = bias
+
+
+def test_train_and_predict_pipeline(
+    tmp_path: Path,
+    fake_umg_csv: Path,
+    fake_weather_parquet: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end smoke test for train/predict pipelines with lightweight mocks."""
+    from ai_hibrid.pipeline import predict as predict_module
+    from ai_hibrid.pipeline import train as train_module
+
+    logger.info("Running hybrid pipeline train/predict test")
+
+    timestamps = pd.date_range("2024-01-01T00:00:00Z", periods=24, freq="1h", tz="UTC")
+    base = np.arange(len(timestamps), dtype=float)
+    physics = pd.Series(100 + base, index=timestamps, name="power_physics_W")
+    feature = pd.Series(base, index=timestamps, name="feature_a")
+    target = physics + 5
+
+    dataset = pd.concat([feature, physics, target.rename("target_power_W")], axis=1)
+    features_only = dataset.drop(columns=["target_power_W"])
+
+    config_payload = {"site": {"timezone": "UTC"}}
+    monkeypatch.setattr(train_module, "load_config", lambda path: config_payload)
+    monkeypatch.setattr(predict_module, "load_config", lambda path: config_payload)
+    monkeypatch.setattr(train_module, "build_training_dataset", lambda *_: (dataset.copy(), {}))
+    monkeypatch.setattr(
+        predict_module,
+        "build_feature_matrix",
+        lambda weather, index, cfg, include_lags=True: (features_only.copy(), {}),
+    )
+
+    def fake_train_xgb(features: pd.DataFrame, target: pd.Series, validation_fraction: float = 0.2):
+        model = DummyModel(bias=float(target.mean()))
+        metrics = {"mape": 0.1, "rmse": 0.5}
+        return model, metrics
+
+    def fake_predict_xgb(model: DummyModel, features: pd.DataFrame):
+        return [model.bias + idx * 0.01 for idx in range(len(features))]
+
+    monkeypatch.setattr(train_module, "train_xgb", fake_train_xgb)
+    monkeypatch.setattr(train_module, "predict_xgb", fake_predict_xgb)
+    monkeypatch.setattr(predict_module, "predict_xgb", fake_predict_xgb)
+    monkeypatch.setattr(train_module, "tune_alpha", lambda *_, **__: (0.4, 1.0))
+    monkeypatch.setattr(train_module, "blend_predictions", lambda physics, ml, alpha: physics * (1 - alpha) + ml * alpha)
+    monkeypatch.setattr(
+        predict_module,
+        "blend_predictions",
+        lambda physics, ml, alpha: physics * (1 - alpha) + ml * alpha,
+    )
+
+    artifact_root = tmp_path / "artifacts"
+    metrics = train_module.train_pipeline(
+        str(fake_umg_csv),
+        str(fake_weather_parquet),
+        str(tmp_path / "config.yaml"),
+        artifact_root=artifact_root,
+    )
+    assert set(metrics.keys()) >= {"physics", "ml", "blended"}
+
+    forecast_path = tmp_path / "forecast.csv"
+    predict_module.predict_pipeline(
+        str(fake_weather_parquet),
+        str(tmp_path / "config.yaml"),
+        horizon=6,
+        out_path=forecast_path,
+        artifact_root=artifact_root,
+    )
+    assert forecast_path.exists()
+    forecast = pd.read_csv(forecast_path)
+    assert {
+        "forecast_power_physics_W",
+        "forecast_power_ml_W",
+        "forecast_power_W",
+    }.issubset(forecast.columns)
+    assert forecast["forecast_power_W"].notna().all()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,16 @@
+"""Application level smoke tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import get_test_logger
+
+logger = get_test_logger(__name__)
+logger.info("Starting tests for app module")
+
+
+def test_app_health_endpoint_absent() -> None:
+    """Skip gracefully when no HTTP application is defined."""
+    logger.info("No dedicated FastAPI application exposed in app package; skipping")
+    pytest.skip("app package does not expose a FastAPI application")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,141 @@
+"""CLI smoke tests using Typer's runner with extensive mocking."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+from typer.testing import CliRunner
+
+from tests.conftest import get_test_logger
+from tests.helpers import FakeVpnConnection
+
+logger = get_test_logger(__name__)
+logger.info("Starting tests for CLI module")
+
+
+def _prepare_runner() -> CliRunner:
+    runner = CliRunner()
+    return runner
+
+
+def test_cli_help(monkeypatch) -> None:
+    """Base --help command renders without prompting for language."""
+    from cli import app as cli_app
+
+    logger.info("Running CLI --help test")
+    monkeypatch.setattr(cli_app, "configure_logging", lambda *_: None)
+
+    runner = _prepare_runner()
+    with runner.isolated_filesystem():
+        Path(".progonzarc").write_text("lang=en", encoding="utf-8")
+        result = runner.invoke(cli_app.app, ["--help"])
+    assert result.exit_code == 0
+    assert "PROGONZA" in result.stdout
+
+
+def test_vpn_commands(monkeypatch) -> None:
+    """Exercise vpn status/connect/disconnect commands using fake VPN."""
+    from cli import app as cli_app
+    from cli.subapps import vpn as vpn_cli
+
+    logger.info("Running CLI VPN command tests")
+
+    monkeypatch.setattr(cli_app, "configure_logging", lambda *_: None)
+    monkeypatch.setattr(vpn_cli, "VPNConnection", FakeVpnConnection)
+    monkeypatch.setattr(vpn_cli, "_check_tcp", lambda *_: True)
+
+    runner = _prepare_runner()
+    with runner.isolated_filesystem():
+        Path(".progonzarc").write_text("lang=en", encoding="utf-8")
+        status = runner.invoke(cli_app.app, ["vpn", "status"])
+        connect = runner.invoke(cli_app.app, ["vpn", "connect"])
+        disconnect = runner.invoke(cli_app.app, ["vpn", "disconnect"])
+
+    assert status.exit_code == 0 and "is_connected" in status.stdout
+    assert connect.exit_code == 0 and "vpn_ip" in connect.stdout
+    assert disconnect.exit_code == 0
+
+
+def test_system_vpn_weather(monkeypatch) -> None:
+    """system vpn-weather completes quickly with mocked scheduler and router."""
+    from cli import app as cli_app
+    from cli.subapps import system as system_cli
+
+    logger.info("Running system vpn-weather test")
+
+    call_log: List[float | None] = []
+
+    monkeypatch.setattr(cli_app, "configure_logging", lambda *_: None)
+
+    class DummyRouter:
+        def __init__(self) -> None:
+            self.nowcast_calls = 0
+            self.hourly_calls = 0
+
+        def get_nowcast(self, hours: int):
+            self.nowcast_calls += 1
+            idx = pd.date_range("2024-01-01T00:00:00Z", periods=hours * 4, freq="15min", tz="UTC")
+            return pd.DataFrame({"temp_C": range(len(idx))}, index=idx)
+
+        def get_hourly(self, start, end):
+            self.hourly_calls += 1
+            idx = pd.date_range(start, end, freq="1h", tz="UTC")
+            return pd.DataFrame({"temp_C": range(len(idx))}, index=idx)
+
+    router = DummyRouter()
+
+    monkeypatch.setattr(system_cli, "_build_router", lambda *_: router)
+    monkeypatch.setattr(system_cli, "_persist_weather", lambda *_, **__: None)
+
+    current = {"value": 0.0}
+
+    def fake_time() -> float:
+        current["value"] += 1.0
+        return current["value"]
+
+    def fake_sleep(seconds: float) -> None:
+        current["value"] += seconds
+
+    def fake_sleep_until(target: float) -> None:
+        current["value"] = max(current["value"], target)
+
+    monkeypatch.setattr(system_cli.time, "time", fake_time)
+    monkeypatch.setattr(system_cli.time, "sleep", fake_sleep)
+    monkeypatch.setattr(system_cli, "_sleep_until", fake_sleep_until)
+
+    def fake_poll_once(*, scheduled_wall_time=None, **_):
+        call_log.append(scheduled_wall_time)
+        return {"start_delay_s": 0.0}
+
+    monkeypatch.setattr(system_cli, "poll_once", fake_poll_once)
+
+    runner = _prepare_runner()
+    with runner.isolated_filesystem():
+        Path(".progonzarc").write_text("lang=en", encoding="utf-8")
+        result = runner.invoke(
+            cli_app.app,
+            ["system", "vpn-weather", "--duration", "5"],
+        )
+
+    assert result.exit_code == 0
+    assert call_log, "poll_once should be invoked at least once"
+    assert "Scenariul" in result.stdout
+
+
+def test_ui_start_command(monkeypatch, mock_uvicorn) -> None:
+    """UI start subcommand delegates to the patched uvicorn entrypoint."""
+    from cli import app as cli_app
+
+    logger.info("Running CLI UI start test")
+
+    monkeypatch.setattr(cli_app, "configure_logging", lambda *_: None)
+
+    runner = _prepare_runner()
+    with runner.isolated_filesystem():
+        Path(".progonzarc").write_text("lang=en", encoding="utf-8")
+        result = runner.invoke(cli_app.app, ["ui", "start", "--open"])
+
+    assert result.exit_code == 0
+    assert mock_uvicorn["start"] == ("127.0.0.1", 8090, True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,104 @@
+"""Core module tests covering scheduling and data quality."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tests.conftest import get_test_logger
+
+logger = get_test_logger(__name__)
+logger.info("Starting tests for core module")
+
+
+def test_poll_loop_alignment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the polling loop aligns to minute boundaries with a fake clock."""
+    from app import poll
+
+    logger.info("Running poll loop alignment test")
+
+    current = {"wall": 100.0, "mono": 50.0}
+    scheduled_calls: list[float | None] = []
+
+    def fake_time() -> float:
+        return current["wall"]
+
+    def fake_monotonic() -> float:
+        return current["mono"]
+
+    def fake_sleep(seconds: float) -> None:
+        current["wall"] += seconds
+        current["mono"] += seconds
+
+    def fake_poll_once(*, scheduled_wall_time: float | None = None, **_: object) -> dict[str, object]:
+        scheduled_calls.append(scheduled_wall_time)
+        payload = {
+            "start_delay_s": 0.0,
+            "started_at": current["wall"],
+            "scheduled_start": scheduled_wall_time,
+        }
+        current["wall"] += 0.5
+        current["mono"] += 0.5
+        return payload
+
+    monkeypatch.setattr(poll.time, "time", fake_time)
+    monkeypatch.setattr(poll.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(poll.time, "sleep", fake_sleep)
+    monkeypatch.setattr(poll, "poll_once", fake_poll_once)
+    monkeypatch.setattr("builtins.print", lambda *_, **__: None)
+
+    poll.poll_loop(interval_s=60, cycles=3, sync=True)
+
+    assert scheduled_calls == [120.0, 180.0, 240.0]
+
+
+def test_data_quality_validation_and_repair(tmp_path: Path) -> None:
+    """Validate and repair a tiny CSV ensuring gaps are filled deterministically."""
+    from core.data_quality import auto_repair_csv, validate_csv
+
+    logger.info("Running data quality validation test")
+
+    index = pd.date_range("2024-01-01T00:00:00Z", periods=5, freq="1min")
+    frame = pd.DataFrame(
+        {
+            "timestamp": index.astype(str),
+            "power_active_total": [10, 11, 12, 13, 14],
+            "power_reactive_total": [1, 1, 1, 1, 1],
+        }
+    )
+    full_csv = tmp_path / "umg" / "full.csv"
+    full_csv.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_csv(full_csv, index=False)
+
+    cfg = {"timezone": "UTC", "drift_sec_max": 3, "ranges": {}, "forward_fill_max": 2}
+    result = validate_csv(full_csv, cfg)
+    assert result["ok"] is True
+    assert result["stats"]["missing_rate"] == pytest.approx(0.0, abs=1e-6)
+
+    gapped = frame.drop(2).reset_index(drop=True)
+    csv_path = tmp_path / "umg" / "sample.csv"
+    gapped.to_csv(csv_path, index=False)
+
+    repair_out = tmp_path / "umg" / "repaired.csv"
+    repaired = auto_repair_csv(csv_path, repair_out, cfg)
+    generated = repaired["repair"]["generated_rows"]
+    assert generated >= 1
+    repaired_frame = pd.read_csv(repair_out)
+    assert len(repaired_frame) >= len(frame)
+
+
+def test_vpn_connection_context(mock_vpn: Path) -> None:
+    """Exercise VPN connect/disconnect flows using the fake manager."""
+    from app.vpn_connection import VPNConnection
+
+    logger.info("Running VPN connection happy-path test")
+
+    vpn = VPNConnection()
+    status = vpn.connect()
+    assert status["is_connected"] is True
+    vpn.disconnect()
+    final_status = vpn.status()
+    assert final_status["is_connected"] is False

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,30 @@
+"""Validation tests for automation scripts repository."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import get_test_logger
+
+logger = get_test_logger(__name__)
+logger.info("Starting tests for scripts module")
+
+
+@pytest.fixture(scope="module")
+def scripts_root(project_root: Path) -> Path:
+    path = project_root / "scripts"
+    if not path.exists():
+        pytest.skip("scripts directory missing")
+    return path
+
+
+def test_scripts_catalog_contains_weather_helpers(scripts_root: Path) -> None:
+    """Ensure bundled PowerShell helpers for weather fetching are present."""
+    logger.info("Inspecting scripts catalog")
+    power_shell_scripts = list(scripts_root.glob("fetch_weather_*.ps1"))
+    assert power_shell_scripts, "Expected PowerShell weather scripts to exist"
+    for script in power_shell_scripts:
+        contents = script.read_text(encoding="utf-8")
+        assert "weather" in contents.lower()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,85 @@
+"""FastAPI UI smoke-tests covering key endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+from fastapi.testclient import TestClient
+
+from tests.conftest import get_test_logger
+
+logger = get_test_logger(__name__)
+logger.info("Starting tests for UI module")
+
+
+def _prepare_ui_dirs(
+    tmp_path: Path,
+    fake_umg_csv: Path,
+    fake_weather_parquet: Path,
+    monkeypatch,
+) -> Dict[str, Path]:
+    from ui import data_access
+
+    data_root = tmp_path / "data"
+    janitza_dir = data_root / "raw" / "umg509"
+    weather_dir = data_root / "weather"
+    janitza_dir.mkdir(parents=True, exist_ok=True)
+    weather_dir.mkdir(parents=True, exist_ok=True)
+
+    target_csv = janitza_dir / fake_umg_csv.name
+    target_csv.write_bytes(Path(fake_umg_csv).read_bytes())
+
+    target_weather = weather_dir / fake_weather_parquet.name
+    target_weather.write_bytes(Path(fake_weather_parquet).read_bytes())
+
+    monkeypatch.setattr(data_access, "JANITZA_DIRS", [janitza_dir])
+    monkeypatch.setattr(data_access, "WEATHER_DIR", weather_dir)
+    monkeypatch.setattr(data_access, "FORECASTS_DIR", weather_dir)
+    monkeypatch.setattr(data_access, "RESAMPLE_RULE", "5min")
+
+    return {
+        "janitza": janitza_dir,
+        "weather": weather_dir,
+    }
+
+
+def test_ui_endpoints(monkeypatch, tmp_path, fake_umg_csv, fake_weather_parquet) -> None:
+    """Exercise primary UI routes using synthetic data."""
+    from ui import server
+
+    logger.info("Running UI endpoint tests")
+
+    _prepare_ui_dirs(tmp_path, fake_umg_csv, fake_weather_parquet, monkeypatch)
+    client = TestClient(server.app)
+
+    resp = client.get("/ui")
+    assert resp.status_code == 200
+    assert "Janitza" in resp.text
+
+    start = "2024-01-01T00:00:00Z"
+    end = "2024-01-01T02:00:00Z"
+    metrics = "power_active_total,power_factor"
+    resp = client.get("/ui/api/janitza", params={"start": start, "end": end, "metrics": metrics})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["series"], "Expected Janitza series"
+    first_series = payload["series"][0]
+    assert first_series["data"], "Series should contain datapoints"
+
+    weather_key = Path(fake_weather_parquet).stem.lower()
+    resp = client.get(
+        "/ui/api/weather",
+        params={"type": weather_key, "start": start, "end": end},
+    )
+    assert resp.status_code == 200
+    weather_payload = resp.json()
+    assert any(series["name"].startswith("temp") for series in weather_payload["series"])
+
+    resp = client.get(
+        "/ui/janitza/table",
+        params={"start": start, "end": end, "metrics": "power_active_total,power_factor"},
+    )
+    assert resp.status_code == 200
+    assert "kW" in resp.text or "Power" in resp.text

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,88 @@
+"""Tests for the weather orchestration layer."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from tests.conftest import get_test_logger
+from tests.helpers import FakeProvider
+
+from weather.router import WeatherRouter
+
+logger = get_test_logger(__name__)
+logger.info("Starting tests for weather module")
+
+
+def _hourly_builder(start: pd.Timestamp, end: pd.Timestamp, calls: dict) -> pd.DataFrame:
+    calls["hourly"] = calls.get("hourly", 0) + 1
+    idx = pd.date_range(start, end, freq="1h")
+    data = {
+        "temp_C": [10 + i for i in range(len(idx))],
+        "wind_ms": [3.0] * len(idx),
+        "wind_deg": [180] * len(idx),
+        "clouds_pct": [20 + i for i in range(len(idx))],
+        "humidity": [60] * len(idx),
+        "uvi": [0.5] * len(idx),
+        "ghi_Wm2": [100 + i for i in range(len(idx))],
+    }
+    return pd.DataFrame(data, index=idx)
+
+
+def _nowcast_builder(hours: int, calls: dict) -> pd.DataFrame:
+    calls["nowcast"] = calls.get("nowcast", 0) + 1
+    idx = pd.date_range("2024-01-01T00:00:00Z", periods=hours * 4, freq="15min", tz="UTC")
+    data = {
+        "temp_C": [5 + i for i in range(len(idx))],
+        "wind_ms": [2.5] * len(idx),
+        "wind_deg": [90] * len(idx),
+        "clouds_pct": [50] * len(idx),
+        "humidity": [55] * len(idx),
+        "uvi": [0.1] * len(idx),
+        "ghi_Wm2": [80] * len(idx),
+    }
+    return pd.DataFrame(data, index=idx)
+
+
+def test_weather_router_caching(monkeypatch) -> None:
+    """Weather router merges providers and honours cache usage."""
+    logger.info("Running weather router test")
+    calls: dict[str, int] = {}
+    provider = FakeProvider(
+        name="fake",
+        priority=1,
+        hourly_builder=lambda start, end: _hourly_builder(start, end, calls),
+        nowcast_builder=lambda hours: _nowcast_builder(hours, calls),
+    )
+    router = WeatherRouter([provider], tz="Europe/Bucharest")
+
+    start = pd.Timestamp("2024-01-01T00:00:00Z")
+    end = start + pd.Timedelta(hours=6)
+
+    hourly = router.get_hourly(start.to_pydatetime(), end.to_pydatetime())
+    assert not hourly.empty
+    assert list(hourly.columns) == [
+        "temp_C",
+        "wind_ms",
+        "wind_deg",
+        "clouds_pct",
+        "humidity",
+        "uvi",
+        "ghi_Wm2",
+        "source",
+    ]
+    assert hourly.index.is_monotonic_increasing
+
+    hourly_cached = router.get_hourly(start.to_pydatetime(), end.to_pydatetime())
+    pd.testing.assert_frame_equal(hourly, hourly_cached)
+    assert calls["hourly"] == 1, "subsequent hourly fetch should hit cache"
+
+    nowcast = router.get_nowcast(2)
+    assert not nowcast.empty
+    assert nowcast.index.is_monotonic_increasing
+
+    nowcast_cached = router.get_nowcast(2)
+    pd.testing.assert_frame_equal(nowcast, nowcast_cached)
+    assert calls["nowcast"] == 1
+
+    local = router.to_local(hourly)
+    assert str(local.index.tz) == "Europe/Bucharest"


### PR DESCRIPTION
## Summary
- add shared pytest configuration with logging hooks, synthetic data fixtures, and network/mocking helpers
- implement targeted tests across AI, CLI, UI, weather, and supporting modules using the new helpers
- document how to run the deterministic pytest suite in the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ed53f1ed0483308620b02609824c15